### PR TITLE
Add simple pytest fixtures example

### DIFF
--- a/PythonTest_18082025/Day3/Solutions/test_fixtures.py
+++ b/PythonTest_18082025/Day3/Solutions/test_fixtures.py
@@ -1,46 +1,34 @@
 import pytest
 
-# я студент и пишу простые примеры фикстур
-
-
 @pytest.fixture()
 def sample_list():
-    # я сделал так, потому что вернуть список проще всего
+    # Проще всего вернуть список
     return [1, 2, 3]
-
 
 @pytest.fixture()
 def sample_dict():
     """простой словарь для pytest --fixtures"""
-    # тоже ничего сложного, просто два ключа
+    # Просто два ключа
     return {"a": 1, "b": 2}
-
 
 @pytest.fixture(scope="module")
 def sample_tuple():
-    # scope="module" значит, что фикстура вызывается один раз на модуль, а не перед каждым тестом
+    # scope="module" - фикстура вызывается один раз на модуль, а не перед каждым тестом
     print("setup")  # имитация подготовки ресурса
     yield (1, 2, 3)  # я возвращаю кортеж через yield
     print("teardown")  # имитация очистки ресурса
 
-
-# мы будем запускать: pytest --setup-show test_fixtures.py,
-# чтобы убедиться, что фикстуры вызываются перед каждым тестом
-
+# pytest --setup-show test_fixtures.py, чтобы убедиться, что фикстуры вызываются перед каждым тестом
 
 def test_list_length(sample_list):
     assert len(sample_list) == 3
-
 
 def test_list_sum(sample_list):
     # тут мы снова используем ту же фикстуру sample_list
     assert sum(sample_list) == 6
 
-
 def test_dict_contents(sample_dict):
     assert sample_dict["a"] == 1
 
-
 def test_tuple_first(sample_tuple):
     assert sample_tuple[0] == 1
-


### PR DESCRIPTION
## Summary
- add student-style pytest fixtures returning list, dict, and module-scoped tuple with setup/teardown
- demonstrate tests that reuse fixtures

## Testing
- `pytest --setup-show PythonTest_18082025/Day3/Solutions/test_fixtures.py`
- `pytest --fixtures PythonTest_18082025/Day3/Solutions/test_fixtures.py | grep -n -A1 sample_dict`


------
https://chatgpt.com/codex/tasks/task_e_68a5bd6264c8832381405c15ff481ea4